### PR TITLE
Ignore single line comments when parsing imports

### DIFF
--- a/commands/update.ts
+++ b/commands/update.ts
@@ -217,7 +217,8 @@ async function updateImportMap(
 function codeUrls(content: string): Map<string, Package> {
   const packages: Map<string, Package> = new Map();
 
-  content = content.split('\n').filter((line) => !line.trim().startsWith('//')).join('\n');
+  content = content.split("\n").filter((line) => !line.trim().startsWith("//"))
+    .join("\n");
   // content = content.replaceAll(/^\/\/.*$/g, ""); // remove comments
 
   for (const R of registries) {

--- a/commands/update.ts
+++ b/commands/update.ts
@@ -217,6 +217,9 @@ async function updateImportMap(
 function codeUrls(content: string): Map<string, Package> {
   const packages: Map<string, Package> = new Map();
 
+  content = content.split('\n').filter((line) => !line.trim().startsWith('//')).join('\n');
+  // content = content.replaceAll(/^\/\/.*$/g, ""); // remove comments
+
   for (const R of registries) {
     const allRegexp = R.regexp.map((r) =>
       new RegExp(`['"\\s]${r.source}['"\\s$]`, "g")

--- a/tests/code-expected.txt
+++ b/tests/code-expected.txt
@@ -14,6 +14,7 @@ import "npm:foo-bar@0.2.0";
 import "npm:foo-bar@0.2.0/mod.ts";
 import "npm:@foo/bar@0.2.0";
 import "npm:@foo/bar@0.2.0/mod.ts";
+// not an import import "npm:@foo/bar";
 import "https://x.nest.land/foo-bar@0.2.0/mod.ts";
 import "https://cdn.skypack.dev/foo-bar@0.2.0";
 import "https://cdn.skypack.dev/@foo/bar@0.2.0/mod.ts";

--- a/tests/code.txt
+++ b/tests/code.txt
@@ -14,6 +14,7 @@ import "npm:foo-bar@0.1.0";
 import "npm:foo-bar@0.1.0/mod.ts";
 import "npm:@foo/bar@0.1.0";
 import "npm:@foo/bar@0.1.0/mod.ts";
+// not an import import "npm:@foo/bar";
 import "https://x.nest.land/foo-bar@0.1.0/mod.ts";
 import "https://cdn.skypack.dev/foo-bar@0.1.0";
 import "https://cdn.skypack.dev/@foo/bar@0.1.0/mod.ts";


### PR DESCRIPTION
Currently, if there is a package mentioned in a comment, it gets updated. This is not a behavior that I would expect, I refer to a particular version in a comment and would like it to stay.